### PR TITLE
fix: use the most recent changed time of SA advisories to determine what to download

### DIFF
--- a/scripts/download_sa_advisories.py
+++ b/scripts/download_sa_advisories.py
@@ -73,5 +73,5 @@ def download_sa_advisories_from_rest_api(last_modified_timestamp: int):
       fetch_again = False
 
 
-last_modified_timestamp = get_most_recent_changed_timestamp()
-download_sa_advisories_from_rest_api(last_modified_timestamp)
+most_recent_changed_time = get_most_recent_changed_timestamp()
+download_sa_advisories_from_rest_api(most_recent_changed_time)


### PR DESCRIPTION
Since the OSVs are committed to the codebase whereas the cache is not, it's possible for the "last modified" time to get ahead of the caches actual age, after which it's very unlikely to get properly updated - instead, we should be using the changed time of the advisories in the local cache to ensure each cache ends up with the most recent data