### PR TITLE
feat: improve output of scripts

### DIFF
--- a/scripts/download_sa_advisories.py
+++ b/scripts/download_sa_advisories.py
@@ -74,7 +74,7 @@ def download_sa_advisories_from_rest_api(last_modified_timestamp: int):
         else:
           # We have reached the last modified entry.
           fetch_again = False
-      print(' \- finished processing page')
+      print(' \\- finished processing page')
       if 'next' in data and data['next'] != '':
         url = data['next'].replace('api-d7/node?', 'api-d7/node.json?')
       else:

--- a/scripts/generate_osv_advisories.py
+++ b/scripts/generate_osv_advisories.py
@@ -235,12 +235,12 @@ def build_osv_advisory(
   # we expect that the downloader has excluded PSA type entries, but
   # we still guard against them here just in case one slips through
   if sa_json['field_is_psa'] == '1':
-    print(' \- skipping as it is a psa? (this should not happen)')
+    print(' \\- skipping as it is a psa? (this should not happen)')
     return None
 
   # there's not really much we can do if there isn't an affected version
   if sa_json['field_affected_versions'] is None:
-    print(' \- skipping as we do not have any affected versions')
+    print(' \\- skipping as we do not have any affected versions')
     return None
 
   osv_entry: osv.Vulnerability = osv_template(sa_id)


### PR DESCRIPTION
This does a basic rework of our output to be more structured, using pipes and indenting to create bit of a relationship in the output:

```
fetching sa advisories modified after 0
fetching https://www.drupal.org/api-d7/node.json?type=sa&sort=changed&direction=DESC&field_is_psa=0&page=8
 |- updating cache/advisories/SA-CONTRIB-2021-037.json as https://www.drupal.org/sa-contrib-2021-037 has changed
 |- ...
 |- updating cache/advisories/SA-CONTRIB-2022-058.json as https://www.drupal.org/sa-contrib-2022-058 has changed
 \- finished processing page
fetching https://www.drupal.org/api-d7/node.json?type=sa&sort=changed&direction=DESC&field_is_psa=0&page=9
 |- updating cache/advisories/SA-CONTRIB-2022-057.json as https://www.drupal.org/sa-contrib-2022-057 has changed
 |- ...
 |- updating cache/advisories/SA-CONTRIB-2023-010.json as https://www.drupal.org/sa-contrib-2023-010 has changed
 \- finished processing page
finished processing new and updated advisories
```

and

```
processing https://www.drupal.org/sa-contrib-2020-010
processing https://www.drupal.org/sa-core-2018-004
processing https://www.drupal.org/sa-contrib-2025-002
processing https://www.drupal.org/sa-contrib-2017-089
 \- skipping as we do not have any affected versions
processing https://www.drupal.org/sa-contrib-2024-047
processing https://www.drupal.org/sa-contrib-2025-027
processing https://www.drupal.org/sa-core-2021-007
processing https://www.drupal.org/sa-contrib-2022-046
processing https://www.drupal.org/sa-contrib-2019-035
 \- skipping as we do not have any affected versions
processing https://www.drupal.org/sa-contrib-2021-002
```

I'm not expecting this to withstand the test of time, but for now it should help make it easier to understand whats happening and (importantly) look up the original data
