### PR TITLE
ci: run `ruff check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/ruff-action@v3
         with:
+          args: 'check'
+      - uses: astral-sh/ruff-action@v3
+        with:
           args: 'format --check --diff'


### PR DESCRIPTION
This will help catch potential bugs and keep us consistent - for now we're just using the default linters which I believe are very permissive, but I'll add a more fulsome config in a follow up