### PR TITLE
refactor: avoid unneeded inner loop and condition when assigning affected events

### DIFF
--- a/scripts/generate_osv_advisories.py
+++ b/scripts/generate_osv_advisories.py
@@ -281,10 +281,8 @@ def build_osv_advisory(
   affected_versions = parse_affected_versions(sa_json['field_affected_versions'])
   affected_versions = add_fixed_in_versions(affected_versions, fixed_in_json)
   affected_versions = sort_affected_versions(affected_versions)
-  if len(affected_versions) > 0:
-    for affected in affected_versions:
-      for [event, version] in affected.items():
-        osv_entry['affected'][0]['ranges'][0]['events'].append({event: version})
+  for event in affected_versions:
+    osv_entry['affected'][0]['ranges'][0]['events'].append(event)
 
   if len(sa_json['field_sa_cve']) > 0:
     for cve in sa_json['field_sa_cve']:


### PR DESCRIPTION
`affected_versions` already holds `osv.Event` objects so we can just directly append them rather than recreating them, which also makes the type checker happier - we can also skip checking the length since looping over an empty list will do nothing anyway.

I've also renamed the loop variable to better reflect the type, and to serve as a bit of a visible indicator that the related variable and function names are a bit inaccurate and so should be cleaned up at some point (which'll happen "soon")