### PR TITLE
refactor: always grab the drupal project

### DIFF
--- a/scripts/generate_osv_advisories.py
+++ b/scripts/generate_osv_advisories.py
@@ -244,11 +244,8 @@ def build_osv_advisory(
     return None
 
   osv_entry: osv.Vulnerability = osv_template(sa_id)
-  project_json: drupal.ApiResponse[drupal.ProjectModule] | None = None
+  project_json = get_project_entry(sa_json['field_project']['id'])
   fixed_in_json: list[drupal.ApiResponse[drupal.ProjectRelease]] = []
-
-  if sa_json['field_project']['id'] != '0':
-    project_json = get_project_entry(sa_json['field_project']['id'])
 
   if len(sa_json['field_fixed_in']) > 0:
     for fixed_in in sa_json['field_fixed_in']:


### PR DESCRIPTION
This condition always seems to be true since later code expects `project_json` to not be `None` and the script is not crashing, so we can remove it to make the type checker happy.

I'm optimistically assuming that there will always be a project as we can't process an advisory that doesn't have one, and I can't imagine any reason why there wouldn't be one