### PR TITLE
fix: don't require `cache/advisories` to exist when determining most recent change time

### DIFF
--- a/scripts/download_sa_advisories.py
+++ b/scripts/download_sa_advisories.py
@@ -24,14 +24,17 @@ def get_most_recent_changed_timestamp() -> int:
   Determines the timestamp of the most recently changed SA advisory
   """
   most_recent_changed = 0
-  for file in os.scandir(cache_dir_name):
-    if not file.is_file() or not file.name.endswith('.json'):
-      continue
-    with open(file.path) as f:
-      advisory = typing.cast(drupal.Advisory, json.load(f))
-      changed = int(advisory['changed'])
-      if changed > most_recent_changed or most_recent_changed == 0:
-        most_recent_changed = changed
+  try:
+    for file in os.scandir(cache_dir_name):
+      if not file.is_file() or not file.name.endswith('.json'):
+        continue
+      with open(file.path) as f:
+        advisory = typing.cast(drupal.Advisory, json.load(f))
+        changed = int(advisory['changed'])
+        if changed > most_recent_changed or most_recent_changed == 0:
+          most_recent_changed = changed
+  except FileNotFoundError:
+    pass
   return most_recent_changed
 
 


### PR DESCRIPTION
The related directories don't get created until we actually start downloading, but since it means that the cache doesn't exist at all we can just return `0` to have everything downloaded