### PR TITLE
ci: run `mypy` against scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
         with:
           python-version: '3.13'
       - run: python3 -m pip install mypy semver requests types-requests
-      - run: mypy scripts/download_sa_advisories.py scripts/generate_osv_advisories.py
+      - run: mypy .


### PR DESCRIPTION
This should help avoid bugs and ensuring the scripts can actually run - for now we're just installing dependencies in the actual job and running against specific scripts since we don't have a proper dependency manifest, and are not using strict mode as I'll address those later