### PR TITLE
refactor: improve type safety of `drupal.ApiResponse`

### DIFF
--- a/scripts/download_sa_advisories.py
+++ b/scripts/download_sa_advisories.py
@@ -53,7 +53,7 @@ def download_sa_advisories_from_rest_api(last_modified_timestamp: int):
     print(f'fetching {url}')
     response = requests.get(url)
     if response.status_code == 200:
-      data: drupal.ApiResponse = response.json()
+      data: drupal.ApiResponse[drupal.Advisory] = response.json()
       for item in data['list']:
         changed = int(item['changed'])
         if changed > last_modified_timestamp:

--- a/scripts/typings/drupal.py
+++ b/scripts/typings/drupal.py
@@ -44,10 +44,7 @@ class ProjectRelease(Node):
   field_release_version_patch: str
 
 
-TNode = typing.TypeVar('TNode', bound=Node)
-
-
-class ApiResponse(typing.TypedDict, typing.Generic[TNode]):
+class ApiResponse[TNode: Node = Node](typing.TypedDict):
   self: str
   first: str
   last: str


### PR DESCRIPTION
It seems in Python generics default to `Any` even if they have an upper bound, so we should explicitly be defining `Node` as the default type for `drupal.ApiResponse`.

I've also switched us to using the new type parameter syntax introduced in [PEP-695](https://peps.python.org/pep-0695/) and available in Python 3.13, which means we no longer have to define a separate variable for the generic.