### PR TITLE
refactor: simplify population of osv dict

### DIFF
--- a/scripts/generate_osv_advisories.py
+++ b/scripts/generate_osv_advisories.py
@@ -194,13 +194,17 @@ def build_osv_advisory(
 
   osv_advisory: osv.Vulnerability = {
     'schema_version': '1.3.0',
-    'id': '',
-    'modified': '',
-    'published': '',
-    'aliases': [],
+    'id': sa_id,
+    'modified': datetime.fromtimestamp(int(sa_advisory['changed'])).strftime(
+      '%Y-%m-%dT%H:%M:%S.000Z'
+    ),
+    'published': datetime.fromtimestamp(int(sa_advisory['created'])).strftime(
+      '%Y-%m-%dT%H:%M:%S.000Z'
+    ),
+    'aliases': sa_advisory['field_sa_cve'],
     'related': [],
     'summary': '',
-    'details': '',
+    'details': sa_advisory['field_sa_description']['value'],
     'affected': [
       {
         'package': {'ecosystem': 'Drupal', 'name': ''},
@@ -208,25 +212,13 @@ def build_osv_advisory(
         'ranges': [
           {
             'type': 'ECOSYSTEM',
-            'events': [
-              # {
-              #     "introduced": cve['containers']['cna']['affected'][0]['versions'][0]['version']
-              # },
-              # {
-              #     "fixed": cve['containers']['cna']['affected'][0]['versions'][0]['version']
-              # }
-            ],
+            'events': [],
           }
         ],
       }
     ],
-    'references': [
-      # {
-      #     "type": "WEB",
-      #     "url": ''
-      # }
-    ],
-    'credits': [],
+    'references': [{'type': 'WEB', 'url': sa_advisory['url']}],
+    'credits': get_credits_from_sa(sa_advisory['field_sa_reported_by']),
   }
   project = typing.cast(
     drupal.Project, fetch_drupal_node(sa_advisory['field_project']['id'])
@@ -235,11 +227,6 @@ def build_osv_advisory(
     typing.cast(drupal.ProjectRelease, fetch_drupal_node(fixed_in['id']))
     for fixed_in in sa_advisory['field_fixed_in']
   ]
-
-  if 'field_sa_reported_by' in sa_advisory:
-    osv_advisory['credits'] = get_credits_from_sa(sa_advisory['field_sa_reported_by'])
-
-  osv_advisory['id'] = f'{sa_id}'
 
   # TODO: Add the severity to the OSV entry.
   # https://ossf.github.io/osv-schema/#severitytype-field
@@ -253,24 +240,12 @@ def build_osv_advisory(
     osv_advisory['affected'][0]['severity'] = []
 
   osv_advisory['affected'][0]['package']['name'] = composer_package(project)
-  osv_advisory['published'] = datetime.fromtimestamp(
-    int(sa_advisory['created'])
-  ).strftime('%Y-%m-%dT%H:%M:%S.000Z')
-  osv_advisory['modified'] = datetime.fromtimestamp(
-    int(sa_advisory['changed'])
-  ).strftime('%Y-%m-%dT%H:%M:%S.000Z')
 
   affected_versions = parse_affected_versions(sa_advisory['field_affected_versions'])
   affected_versions = add_fixed_in_versions(affected_versions, project_releases)
   affected_versions = sort_affected_versions(affected_versions)
   for event in affected_versions:
     osv_advisory['affected'][0]['ranges'][0]['events'].append(event)
-
-  for cve in sa_advisory['field_sa_cve']:
-    osv_advisory['aliases'].append(cve)
-
-  osv_advisory['details'] = sa_advisory['field_sa_description']['value']
-  osv_advisory['references'].append({'type': 'WEB', 'url': sa_advisory['url']})
 
   fake_ecosystem(osv_advisory)
 


### PR DESCRIPTION
This inlines the `osv_template` function and moves all of our field assignments that don't involve conditions or heavy transformations into the initialization of the dict itself