### PR TITLE
fix: don't attempt to sort `affected` events

### DIFF
--- a/advisories/acquia_dam/osv-sa-contrib-2024-025.json
+++ b/advisories/acquia_dam/osv-sa-contrib-2024-025.json
@@ -35,6 +35,9 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "1.1.0"
+            },
+            {
               "fixed": "1.1.0-beta3"
             }
           ],

--- a/advisories/diff/osv-sa-contrib-2024-042.json
+++ b/advisories/diff/osv-sa-contrib-2024-042.json
@@ -35,6 +35,9 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "2.0.0"
+            },
+            {
               "fixed": "2.0.0-beta3"
             }
           ],

--- a/advisories/social/osv-sa-contrib-2024-038.json
+++ b/advisories/social/osv-sa-contrib-2024-038.json
@@ -49,6 +49,9 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "13.0.0"
+            },
+            {
               "fixed": "13.0.0-alpha11"
             }
           ],

--- a/advisories/symfony_mailer/osv-sa-contrib-2023-031.json
+++ b/advisories/symfony_mailer/osv-sa-contrib-2023-031.json
@@ -33,6 +33,9 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "1.3.0"
+            },
+            {
               "fixed": "1.3.0-rc3"
             }
           ],

--- a/scripts/generate_osv_advisories.py
+++ b/scripts/generate_osv_advisories.py
@@ -94,7 +94,7 @@ def parse_version_constraint(versions: str) -> list[osv.Event]:
 def build_affected_range(constraint: str) -> osv.Range:
   return {
     'type': 'ECOSYSTEM',
-    'events': sort_affected_versions(parse_version_constraint(constraint)),
+    'events': parse_version_constraint(constraint),
     'database_specific': {'constraint': constraint},
   }
 
@@ -164,25 +164,6 @@ def semver_for_sorting(semver: typing.Any) -> str:
   semver_minor = semver[1]
   semver_patch = semver[2]
   return f'{semver_major}.{semver_minor}.{semver_patch}'
-
-
-def sort_affected_versions(affected_versions: list[osv.Event]) -> list[osv.Event]:
-  sorted_versions = {}
-  return_values = []
-  for affected in affected_versions:
-    if 'introduced' in affected:
-      sorted_versions[semver_for_sorting(affected['introduced'])] = affected
-    if 'fixed' in affected:
-      sorted_versions[semver_for_sorting(affected['fixed'])] = affected
-
-  # sort the dict by the keys assuming the keys are semver strings.
-  sorted_versions = dict(
-    sorted(sorted_versions.items(), key=lambda item: semver.parse_version_info(item[0]))
-  )
-  for key in sorted_versions:
-    return_values.append(sorted_versions[key])
-
-  return return_values
 
 
 def get_credits_from_sa(credits: drupal.RichTextField) -> list[osv.Credit]:


### PR DESCRIPTION
The events should already be sorted since we process version constraints from left to right, and the lower bounds always comes first, and our current sorting implementation both ignores the stability constraint and actually attempts to deduplicate events by their version resulting in some advisories losing their `introduced` event