### PR TITLE
chore: update `git` and `prettier` ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 __pycache__/
 cache/
 node_modules/
+vendor/

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ __pycache__/
 advisories/
 cache/
 node_modules/
+vendor/


### PR DESCRIPTION
These are generally all pretty standard stuff, though I had not realized `__pycache__` was a thing that Python generates as it turns out my IDE magically hides it from me.

I've included the tool caches even though they actually include a `.gitignore` with a wildcard since that doesn't stop `prettier` from checking the directories and I think it's nicer to be consistent between the two files. I've also included `node_modules` and `vendor` since they're traditional and are usually very big so I think it's nice having them as a just-in-case