### PR TITLE
refactor: remove unused "full proposed entry" logic

### DIFF
--- a/scripts/typings/osv.py
+++ b/scripts/typings/osv.py
@@ -94,7 +94,6 @@ SeverityType = typing.Literal[
   'CVSS_V2',
   'CVSS_V3',
   'CVSS_V4',
-  'NIST_CMSS',  # todo: this is not defined in the spec
 ]
 
 


### PR DESCRIPTION
This is a bit of a legacy thing from when we were first figuring out how to do the advisory generation, which I've replaced with todo comments to make it easier to iterate on our generation script