### PR TITLE
docs: suggest `poetry run` be used for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ in `pyproject.toml` using
 
 ```shell
 # 1. download the Drupal SA advisories from drupal.org
-scripts/download_sa_advisories.py
+poetry run scripts/download_sa_advisories.py
 
 # 2. download nodes from drupal.org related to the advisories
 # (this is not required, but will significantly improve performance of the next step)
-scripts/precache_nodes.py
+poetry run scripts/precache_nodes.py
 
 # 3. generate the OSV advisories based on the Drupal advisories
-scripts/generate_osv_advisories.py
+poetry run scripts/generate_osv_advisories.py
 ```


### PR DESCRIPTION
It seems that being able to run the scripts directly is something of a fluke seemingly due to how Poetry actually installs dependencies - sadly it doesn't seem like you can integrate Poetry into the hashbang of the script, so for now I've just updated our documentation to reflect that.

In practice, folks can probably not do that locally (like I've been doing), though I expect in CI you will always have to