### PR TITLE
feat: order affected ranges as they are in the version constraint

### DIFF
--- a/advisories/core/osv-sa-core-2023-005.json
+++ b/advisories/core/osv-sa-core-2023-005.json
@@ -35,6 +35,48 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "9.4.0"
+            },
+            {
+              "fixed": "9.4.14"
+            }
+          ],
+          "database_specific": {
+            "constraint": ">=9.4.0 <9.4.14"
+          }
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "9.5.0"
+            },
+            {
+              "fixed": "9.5.8"
+            }
+          ],
+          "database_specific": {
+            "constraint": ">=9.5.0 <9.5.8"
+          }
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "10.0.0"
+            },
+            {
+              "fixed": "10.0.8"
+            }
+          ],
+          "database_specific": {
+            "constraint": ">=10.0.0 <10.0.8"
+          }
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "8.0.0"
             },
             {
@@ -225,48 +267,6 @@
           ],
           "database_specific": {
             "constraint": "9.3.*"
-          }
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "9.4.0"
-            },
-            {
-              "fixed": "9.4.14"
-            }
-          ],
-          "database_specific": {
-            "constraint": ">=9.4.0 <9.4.14"
-          }
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "9.5.0"
-            },
-            {
-              "fixed": "9.5.8"
-            }
-          ],
-          "database_specific": {
-            "constraint": ">=9.5.0 <9.5.8"
-          }
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "10.0.0"
-            },
-            {
-              "fixed": "10.0.8"
-            }
-          ],
-          "database_specific": {
-            "constraint": ">=10.0.0 <10.0.8"
           }
         }
       ],

--- a/advisories/eca/osv-sa-contrib-2025-031.json
+++ b/advisories/eca/osv-sa-contrib-2025-031.json
@@ -35,20 +35,6 @@
           "type": "ECOSYSTEM",
           "events": [
             {
-              "introduced": "1.2.0"
-            },
-            {
-              "fixed": "1.3.0"
-            }
-          ],
-          "database_specific": {
-            "constraint": "1.2.*"
-          }
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
               "introduced": "2.0.0"
             },
             {
@@ -71,6 +57,20 @@
           ],
           "database_specific": {
             "constraint": ">=2.1.0 <2.1.7"
+          }
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "1.2.0"
+            },
+            {
+              "fixed": "1.3.0"
+            }
+          ],
+          "database_specific": {
+            "constraint": "1.2.*"
           }
         }
       ],

--- a/advisories/persistent_login/osv-sa-contrib-2024-044.json
+++ b/advisories/persistent_login/osv-sa-contrib-2024-044.json
@@ -35,6 +35,20 @@
           "type": "ECOSYSTEM",
           "events": [
             {
+              "introduced": "2.2.0"
+            },
+            {
+              "fixed": "2.2.2"
+            }
+          ],
+          "database_specific": {
+            "constraint": ">=2.2.0 <2.2.2"
+          }
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
               "introduced": "2.0.0"
             },
             {
@@ -57,20 +71,6 @@
           ],
           "database_specific": {
             "constraint": "2.1.*"
-          }
-        },
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "2.2.0"
-            },
-            {
-              "fixed": "2.2.2"
-            }
-          ],
-          "database_specific": {
-            "constraint": ">=2.2.0 <2.2.2"
           }
         }
       ],

--- a/scripts/generate_osv_advisories.py
+++ b/scripts/generate_osv_advisories.py
@@ -291,55 +291,10 @@ def build_affected_ranges(sa_advisory: drupal.Advisory) -> list[osv.Range]:
       'field_affected_versions must be present to determine affected ranges'
     )
 
-  ranges = [
+  return [
     build_affected_range(constraint.strip())
     for constraint in sa_advisory['field_affected_versions'].split('||')
   ]
-
-  return sorted(
-    ranges,
-    key=lambda ran: (event_to_semver_for_sorting(ran['events'][0])),
-  )
-
-
-def event_to_semver_for_sorting(event: osv.Event) -> semver.Version:
-  version = '0.0.0'
-  if 'introduced' in event:
-    version = event['introduced']
-  elif 'fixed' in event:
-    version = event['fixed']
-  return semver.Version.parse(semver_for_sorting(version))
-
-
-def semver_for_sorting(semver: typing.Any) -> str:
-  decrement_semver = False
-  if semver == '':
-    return ''
-  # Check if the semver string starts with a '<' character.
-  if semver[0] == '<':
-    decrement_semver = True
-    semver = semver[1:]
-  semver = semver.strip().split('.')
-  # sanity check the length of the introduced value.
-  while len(semver) < 3:
-    semver.append('0')
-
-  for i in range(3):
-    if semver[i].isnumeric():
-      semver[i] = int(semver[i])
-    else:
-      semver[i] = 0
-
-  if decrement_semver:
-    if semver[2] > 0:
-      semver[2] -= 1
-    elif semver[1] > 0:
-      semver[1] -= 1
-
-  semver_major = semver[0]
-  semver_minor = semver[1]
-  semver_patch = semver[2]
-  return f'{semver_major}.{semver_minor}.{semver_patch}'
 
 
 def get_credits_from_sa(credits: drupal.RichTextField) -> list[osv.Credit]:


### PR DESCRIPTION
I think this is slightly better since if you're comparing against the original version constraint you in theory don't need to search the whole constraint for the particular range, but really the motivation here is that the current sorting function is a bit choppy from a typing perspective - I was initially going to refactor it, but then realized there's not much difference so here we are.

The order of events in each range should not change nor need explicit sorting as I'm 98% sure it's impossible to express a different order unless we have a bug which is its own issue anyway

I'm happy to discuss different sort orders if people have opinions, but also we can revisit this later if needed too 🤷 