### PR TITLE
fix: ensure that "empty" object fields on advisories are handled correctly

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -19,5 +19,6 @@ select = [
 known-first-party = [
   'generate_osv_advisories',
   'user_agent',
-  'typings'
+  'typings',
+  'utils'
 ]

--- a/scripts/download_sa_advisories.py
+++ b/scripts/download_sa_advisories.py
@@ -9,10 +9,10 @@ most recent changed time out of all the existing SA advisories
 
 import json
 import os
-import typing
 
 import requests
 
+import utils
 from typings import drupal
 from user_agent import user_agent
 
@@ -26,11 +26,10 @@ def get_most_recent_changed_timestamp() -> int:
     for file in os.scandir('cache/advisories'):
       if not file.is_file() or not file.name.endswith('.json'):
         continue
-      with open(file.path) as f:
-        advisory = typing.cast(drupal.Advisory, json.load(f))
-        changed = int(advisory['changed'])
-        if changed > most_recent_changed or most_recent_changed == 0:
-          most_recent_changed = changed
+      advisory = utils.load_sa_advisory(file.path)
+      changed = int(advisory['changed'])
+      if changed > most_recent_changed or most_recent_changed == 0:
+        most_recent_changed = changed
   except FileNotFoundError:
     pass
   return most_recent_changed

--- a/scripts/generate_osv_advisories.py
+++ b/scripts/generate_osv_advisories.py
@@ -17,6 +17,7 @@ import requests
 import semver
 from markdownify import markdownify
 
+import utils
 from typings import drupal, osv
 from user_agent import user_agent
 
@@ -318,6 +319,9 @@ def get_credits_from_sa(
 
 
 def determine_composer_package_name(sa_advisory: drupal.Advisory) -> str:
+  if sa_advisory['field_project'] is None:
+    raise Exception('advisory does not have a project!')
+
   project = typing.cast(
     drupal.Project, fetch_drupal_node(sa_advisory['field_project']['id'])
   )
@@ -425,8 +429,7 @@ def generate_osv_advisories() -> None:
     if not file.is_file() or not file.name.endswith('.json'):
       continue
 
-    with open(file.path) as f:
-      sa_advisory: drupal.Advisory = json.load(f)
+    sa_advisory = utils.load_sa_advisory(file.path)
     print(f'processing {sa_advisory["url"]}')
     sa_id = file.name.removesuffix('.json')
     osv_advisory = build_osv_advisory(sa_id, sa_advisory)

--- a/scripts/precache_nodes.py
+++ b/scripts/precache_nodes.py
@@ -12,6 +12,7 @@ from itertools import batched
 
 import requests
 
+import utils
 from typings import drupal
 from user_agent import user_agent
 
@@ -49,9 +50,10 @@ def fetch_and_cache_drupal_nodes() -> None:
     if not file.is_file() or not file.name.endswith('.json'):
       continue
 
-    with open(file.path) as f:
-      sa_advisory: drupal.Advisory = json.load(f)
-    ids.add(sa_advisory['field_project']['id'])
+    sa_advisory = utils.load_sa_advisory(file.path)
+
+    if sa_advisory['field_project'] is not None:
+      ids.add(sa_advisory['field_project']['id'])
 
   for i, batch in enumerate(batched(ids, 50, strict=False)):
     print(f'fetching {len(batch)} nodes ({len(ids) - i * 50 - len(batch)} remaining)')

--- a/scripts/typings/drupal.py
+++ b/scripts/typings/drupal.py
@@ -17,19 +17,40 @@ class Node(typing.TypedDict):
   type: str
 
 
-class Advisory(Node):
+class AdvisoryBase(Node):
   field_is_psa: typing.Literal['0', '1']
   field_affected_versions: str | None
-  field_project: EntityReferenceField
   field_fixed_in: list[EntityReferenceField]
-  field_sa_reported_by: RichTextField | list[typing.Never]
   field_sa_criticality: str
   field_sa_cve: list[str]
-  field_sa_description: RichTextField
   created: str
   changed: str
   title: str
   url: str
+
+
+class Advisory(AdvisoryBase):
+  """
+  Represents an advisory sourced from the Drupal JSON API that has been
+  transformed to make it easier to work with
+  """
+
+  field_project: EntityReferenceField | None
+  field_sa_reported_by: RichTextField
+  field_sa_description: RichTextField
+
+
+class AdvisoryRaw(AdvisoryBase):
+  """
+  Represents an advisory provided by the Drupal JSON API without any post-processing.
+
+  This mainly means that object fields which don't have a value in the database
+  will be represented by an empty list due to how associated arrays in PHP work
+  """
+
+  field_project: EntityReferenceField | list[typing.Never]
+  field_sa_reported_by: RichTextField | list[typing.Never]
+  field_sa_description: RichTextField | list[typing.Never]
 
 
 class Project(Node):

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,32 @@
+import json
+
+from typings import drupal
+
+
+def load_sa_advisory(file_path: str) -> drupal.Advisory:
+  """
+  Loads a Drupal advisory from a json file stored on disk, making some adjustments
+  in the process to make it easier to work with
+  """
+  with open(file_path) as f:
+    raw_advisory: drupal.AdvisoryRaw = json.load(f)
+
+  # noinspection PyTypeChecker
+  # https://youtrack.jetbrains.com/issue/PY-58714/False-positive-TypedDict-has-missing-key-when-using-unpacking
+  sa_advisory: drupal.Advisory = {
+    **raw_advisory,
+    'field_project': None,
+    'field_sa_reported_by': {'format': '1', 'value': ''},
+    'field_sa_description': {'format': '1', 'value': ''},
+  }
+
+  if isinstance(raw_advisory['field_project'], dict):
+    sa_advisory['field_project'] = raw_advisory['field_project']
+
+  if isinstance(raw_advisory['field_sa_reported_by'], dict):
+    sa_advisory['field_sa_reported_by'] = raw_advisory['field_sa_reported_by']
+
+  if isinstance(raw_advisory['field_sa_description'], dict):
+    sa_advisory['field_sa_description'] = raw_advisory['field_sa_description']
+
+  return sa_advisory


### PR DESCRIPTION
So it turns out in some advisories some of these fields are actually empty arrays which I think is because PHP uses associative arrays for what are "objects" in JavaScript, `dict`s in Python, and hashes in Ruby. This means an empty associative array is the same as an empty indexed array, so when being turned into JSON PHP cannot know if it should be an actual array or an empty object so it goes with the former.

While that sounds reasonable, what I'm unsure of is why Drupal would be returning an empty array rather than `null` when there isn't a value for an optional relationship - so this might actually be a bug on the upstreams end, but ultimately we need to handle it here so I've introduced a utility function for loading advisories from JSON which normalizes these properties.

Note that right now this isn't actually fixing anything specific because we're not using any of the properties that actually are arrays in some advisories, but we will do in future as part of processing credits.

Also, having bitten the bullet on introducing a `utils.py` also means we can relocate some of our other utility functions that current live in the main scripts