### PR TITLE
ci: use specific version for `octokit/request-action` action

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -39,7 +39,7 @@ jobs:
           author: |
             github-actions <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: 'feat: update advisories'
-      - uses: octokit/request-action@v2
+      - uses: octokit/request-action@v2.4.0
         if: steps.create-or-update-pull-request.outputs.result != 'unchanged'
         with:
           route: |


### PR DESCRIPTION
It turns out this action does not have a `v2` tag so we need to specify the full version