### PR TITLE
fix: handle rich text field potentially being an empty list

### DIFF
--- a/scripts/generate_osv_advisories.py
+++ b/scripts/generate_osv_advisories.py
@@ -295,11 +295,13 @@ def build_affected_ranges(sa_advisory: drupal.Advisory) -> list[osv.Range]:
   ]
 
 
-def get_credits_from_sa(credits: drupal.RichTextField) -> list[osv.Credit]:
+def get_credits_from_sa(
+  credits: drupal.RichTextField | list[typing.Never],
+) -> list[osv.Credit]:
   credit_list: list[osv.Credit] = []
 
   # Sanity checks.
-  if len(credits) == 0 or 'value' not in credits:
+  if not isinstance(credits, dict):
     return credit_list
   # The credits['value'] is a sting with an ordered list of credits.
   # A credit is a link to the user's profile on drupal.org with the user's name as the link text.

--- a/scripts/typings/drupal.py
+++ b/scripts/typings/drupal.py
@@ -22,7 +22,7 @@ class Advisory(Node):
   field_affected_versions: str | None
   field_project: EntityReferenceField
   field_fixed_in: list[EntityReferenceField]
-  field_sa_reported_by: RichTextField
+  field_sa_reported_by: RichTextField | list[typing.Never]
   field_sa_criticality: str
   field_sa_cve: list[str]
   field_sa_description: RichTextField


### PR DESCRIPTION
So it turns out in some advisories some instances of this field are actually empty arrays which I think is because PHP uses associative arrays for what are "objects" in JavaScript, `dict`s in Python, and hashes in Ruby. This means an empty associative array is the same as an empty indexed array, so when being turned into JSON PHP cannot know if it should be an actual array or an empty object so it goes with the former.

While that sounds reasonable, what I'm unsure of is why Drupal would be returning an empty array rather than `null` when there isn't a value for an optional relationship - so this might actually be a bug on the upstreams end, but either way our types should represent the JSON we have today.

The check we currently have for this field does guard against this, but technically does not narrow the type in a way that `mypy` can understand so I've changed it to use `isinstance`.

(this is a smaller version of #56 which is focused on the impacted field that we're currently using)
