### PR TITLE
ci: give generation workflow an explicit name

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,3 +1,4 @@
+name: Generate
 on:
   workflow_dispatch:
 concurrency:


### PR DESCRIPTION
The default name is the path to the workflow, which is a bit long in the actions log