### PR TITLE
ci: use a dedicated GH token for creating pull requests

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: gr2m/create-or-update-pull-request-action@v1
         id: create-or-update-pull-request
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GENERATOR_GH_TOKEN }}
         with:
           title: 'feat: update advisories'
           body: >


### PR DESCRIPTION
GitHub Actions is not allowed to create or approve pull requests by default due to an organisation-wide setting which cannot be opt'd in for specific repositories only - while I don't think there's a big security risk, the other downside by not using a dedicated token is that CI checks won't run for the pull request; the workflow works around that by using the dispatch API, but it's not as pretty and cannot be used for status checks.

So this switches us to use a dedicated GH token sourced as a secret - the token in question will belong to our Ackama Security Auditor user, and for now only last 30 days. For now I've kept the API dispatch call, but will remove it once I've confirmed this is working