### PR TITLE
ci: remove unneeded manual workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 concurrency:
   # Pushing new changes to a branch will cancel any in-progress CI runs of this workflow
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -41,14 +41,3 @@ jobs:
           author: |
             github-actions <41898282+github-actions[bot]@users.noreply.github.com>
           commit-message: 'feat: update advisories'
-      - uses: octokit/request-action@v2.4.0
-        if: steps.create-or-update-pull-request.outputs.result != 'unchanged'
-        with:
-          route: |
-            POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          workflow_id: ci.yml
-          ref: bot/update-advisories
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We don't need this now that we're using a PAT for the workflow