### PR TITLE
ci: replace pull request creator action

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -29,11 +29,9 @@ jobs:
       - run: poetry run scripts/download_sa_advisories.py
       - run: poetry run scripts/precache_nodes.py
       - run: poetry run scripts/generate_osv_advisories.py
-      - uses: gr2m/create-or-update-pull-request-action@v1
-        id: create-or-update-pull-request
-        env:
-          GITHUB_TOKEN: ${{ secrets.GENERATOR_GH_TOKEN }}
+      - uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.GENERATOR_GH_TOKEN }}
           title: 'feat: update advisories'
           body: >
             🤖 beep boop - looks like there's some changes to the advisories!


### PR DESCRIPTION
The current workflow doesn't seem to be recreating the branch how I'd expect, e.g. the current pull request is conflicted due to #68. I think this is a result of how the action is implemented, and that switching to `peter-evans/create-pull-request` will resolve this as it looks like that uses a different implementation aimed to account for this kind of situation.

This action is also more popular and what we're using in other codebases