### PR TITLE
ci: just remove `python` group all together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,10 +10,6 @@
       "matchDepTypes": ["action"],
       "groupName": "workflows",
       "pinDigests": true
-    },
-    {
-      "matchCategories": ["poetry"],
-      "groupName": "python"
     }
   ]
 }


### PR DESCRIPTION
#81 doesn't seemed to have worked either so for now lets just remove the grouping all together