### PR TITLE
chore: ignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.envrc
+.env*
 .idea/
 .vscode/
 .mypy_cache/


### PR DESCRIPTION
We shouldn't track this, so adding it so the git status is tidy