### PR TITLE
ci: run `osv-linter` over advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - run: git clone https://github.com/ossf/osv-schema /tmp/osv-schema
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
+          cache-dependency-path: '/tmp/osv-schema/tools/osv-linter/go.sum'
           go-version: stable
           check-latest: true
-      - run: git clone https://github.com/ossf/osv-schema /tmp/osv-schema
       - run: go install ./cmd/osv
         working-directory: /tmp/osv-schema/tools/osv-linter
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,9 @@ jobs:
           cache-dependency-path: '/tmp/osv-schema/tools/osv-linter/go.sum'
           go-version: stable
           check-latest: true
-      - run: go install ./cmd/osv
+      - run: go build -o osv-linter ./cmd/osv
         working-directory: /tmp/osv-schema/tools/osv-linter
-
-      - run: osv-linter
+      - run: /tmp/osv-schema/tools/osv-linter/osv-linter
 
   ruff:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
         with:
           path: drupal-advisory-database
           persist-credentials: false
-      - run: ls -aoh
+      - run: |
+          osv-schema/tools/osv-linter/osv-linter record lint --parallel 2 \
+            drupal-advisory-database/advisories/
 
   ruff:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,23 @@ jobs:
           persist-credentials: false
       - run:
           docker run -v $PWD:/src ghcr.io/google/osv-scanner:latest scan -r src
+  lint:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version: stable
+          check-latest: true
+      - run: git clone https://github.com/ossf/osv-schema /tmp/osv-schema
+      - run: go install ./cmd/osv
+        working-directory: /tmp/osv-schema/tools/osv-linter
+
+      - run: osv-linter
+
   ruff:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
 
       - run: osv-schema/tools/osv-linter/osv-linter
 
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - run: ls -aoh
+
   ruff:
     permissions:
       contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
 
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
+          path: drupal-advisory-database
           persist-credentials: false
       - run: ls -aoh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - run: git clone https://github.com/ossf/osv-schema /tmp/osv-schema
+      - run: git clone https://github.com/ossf/osv-schema
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          cache-dependency-path: '/tmp/osv-schema/tools/osv-linter/go.sum'
+          cache-dependency-path: 'osv-schema/tools/osv-linter/go.sum'
           go-version: stable
           check-latest: true
       - run: go build -o osv-linter ./cmd/osv
-        working-directory: /tmp/osv-schema/tools/osv-linter
-      - run: /tmp/osv-schema/tools/osv-linter/osv-linter
+        working-directory: osv-schema/tools/osv-linter
+
+      - run: osv-schema/tools/osv-linter/osv-linter
 
   ruff:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      # build the osv-linter from source
       - run: git clone https://github.com/ossf/osv-schema
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
@@ -54,6 +55,7 @@ jobs:
 
       - run: osv-schema/tools/osv-linter/osv-linter
 
+      # run the linter against our advisories
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           path: drupal-advisory-database

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 15
     steps:
       # build the osv-linter from source
-      - run: git clone https://github.com/ossf/osv-schema
+      - run: git clone --depth 1 https://github.com/ossf/osv-schema
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:


### PR DESCRIPTION
This helps to ensure our advisories are in a good state